### PR TITLE
Alignment issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ Custom segmented picker for SwiftUI
 
 struct SegmentedPickerExample: View {
     let titles: [String]
-    @State var selectedIndex: Int = 0
+    @State var selectedIndex: Int?
 
     var body: some View {
         SegmentedPicker(
             titles,
             selectedIndex: Binding(
                 get: { selectedIndex },
-                set: { selectedIndex = $0 ?? 0 }),
+                set: { selectedIndex = $0 }),
+            selectionAlignment: .bottom,
             content: { item, isSelected in
                 Text(item)
                     .foregroundColor(isSelected ? Color.black : Color.gray )
@@ -25,11 +26,12 @@ struct SegmentedPickerExample: View {
             selection: {
                 VStack(spacing: 0) {
                     Spacer()
-                    Rectangle()
-                        .fill(Color.black)
-                        .frame(height: 1)
+                    Color.black.frame(height: 1)
                 }
             })
+            .onAppear {
+                selectedIndex = 0
+            }
             .animation(.easeInOut(duration: 0.3))
     }
 }
@@ -49,14 +51,14 @@ or this guy with a capsule as selection view:
 
 struct SegmentedPickerExample: View {
     let titles: [String]
-    @State var selectedIndex: Int = 0
+    @State var selectedIndex: Int?
 
     var body: some View {
         SegmentedPicker(
             titles,
             selectedIndex: Binding(
                 get: { selectedIndex },
-                set: { selectedIndex = $0 ?? 0 }),
+                set: { selectedIndex = $0 }),
             content: { item, isSelected in
                 Text(item)
                     .foregroundColor(isSelected ? Color.white : Color.gray )
@@ -67,6 +69,9 @@ struct SegmentedPickerExample: View {
                 Capsule()
                     .fill(Color.gray)
             })
+            .onAppear {
+                selectedIndex = 0
+            }
             .animation(.easeInOut(duration: 0.3))
     }
 }

--- a/Sources/SegmentedPicker/SegmentedPicker.swift
+++ b/Sources/SegmentedPicker/SegmentedPicker.swift
@@ -20,9 +20,11 @@ public struct SegmentedPicker<Element, Content, Selection>: View
     private let data: Data
     private let selection: () -> Selection
     private let content: (Data.Element, Bool) -> Content
+    private let selectionAlignment: VerticalAlignment
 
     public init(_ data: Data,
                 selectedIndex: Binding<Data.Index?>,
+                selectionAlignment: VerticalAlignment = .center,
                 @ViewBuilder content: @escaping (Data.Element, Bool) -> Content,
                 @ViewBuilder selection: @escaping () -> Selection) {
 
@@ -32,11 +34,12 @@ public struct SegmentedPicker<Element, Content, Selection>: View
         self._selectedIndex = selectedIndex
         self._frames = State(wrappedValue: Array(repeating: .zero,
                                                  count: data.count))
+        self.selectionAlignment = selectionAlignment
     }
 
     public var body: some View {
         ZStack(alignment: Alignment(horizontal: .horizontalCenterAlignment,
-                                    vertical: .center)) {
+                                    vertical: selectionAlignment)) {
 
             if let selectedIndex = selectedIndex {
                 selection()


### PR DESCRIPTION
## What has happened?

There were cases, when selection view was not aligned appropriately at first appearance. For example, when SegmentedPicker was embedded into NavigationView and selection view itself was something like:

```swift
VStack {
    Spacer()
    Color.black.frame(height: 1)

}
```

Actually, there are two issues:
1. Incorrect selection view alignment 
2  Incorrect selection view size

Both occured at first rendering of selection view in different alignment positions and could be cured by selecting and re-selecting different items.

## Solution

### 1. Incorrect selection view alignment 

New parameter - ```selectionAlignment``` of ```VerticalAlignment``` type was introduced.
It allows to specify exactly how the selection view should be vertically aligned to segment content items and fixes unwanted jumps of the selection view. 

Default value is ```VerticalAlignment.center``` which is recommended config for capsule-style selection.
However, for underline-style selections,  ```VerticalAlignment.bottom``` is recommended.

(See the Readme for example)


### 2.  Incorrect selection view size 

This is another first-render type of issues. 
The way we get content view sizes with geometry reader doesn't seems to be 100% exact.

```swift
Button(
    content(...)
) 
.background(GeometryReader { proxy in
    Color.clear.onAppear { frames[index] = proxy.frame(in: .global) }
})

```

I don't see any workarounds here other than to trigger segment view re-selection to get the correct appearance.

```swift

@State var selectedIndex: Int?

var body: some View {
    SegmentedPicker(...)
        .onAppear {
            selectedIndex = 0
         }
}

```

(See the Readme for example)


Fixes #2 
